### PR TITLE
Created setup.sh script and global installation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,10 +30,10 @@ wget https://raw.githubusercontent.com/puneetsl/lotion/master/setup.sh
 # Or
 curl https://raw.githubusercontent.com/puneetsl/lotion/master/setup.sh > setup.sh
 
-# Run
-sudo ./setup.sh install
+# Run (with sudo for global installation, without sudo for local installation)
+[sudo] ./setup.sh install
 # Or for native installation
-sudo ./setup.sh install_native
+[sudo] ./setup.sh install_native
 ```
 Or simply clone this repo and run 
 

--- a/README.md
+++ b/README.md
@@ -24,12 +24,6 @@ Here is how it looks
 > Use this [link](https://www.notion.so/?r=55d4c384b54a457490f6cc1799bedc76) to sign up and get ready to manage your life like you have never managed before ([Notion.so](https://www.notion.so/?r=55d4c384b54a457490f6cc1799bedc76))
 
 # Installation
-
-Run setup script directly (you be prompted to type installation type)
-```bash
-curl https://raw.githubusercontent.com/puneetsl/lotion/master/setup.sh | bash
-```
-
 Download setup script
 ```bash
 wget https://raw.githubusercontent.com/puneetsl/lotion/master/setup.sh

--- a/README.md
+++ b/README.md
@@ -26,12 +26,14 @@ Here is how it looks
 # Installation
 Download setup script
 ```bash
-wget https://raw.githubusercontent.com/puneetsl/lotion/master/setup.sh
+wget https://raw.githubusercontent.com/puneetsl/lotion/master/setup.sh 
+# Or
+curl https://raw.githubusercontent.com/puneetsl/lotion/master/setup.sh > setup.sh
 
 # Run
-./setup.sh install
+sudo ./setup.sh install
 # Or for native installation
-./setup.sh install_native
+sudo ./setup.sh install_native
 ```
 Or simply clone this repo and run 
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,16 @@ Here is how it looks
 
 # Installation
 
-Simply clone this repo and run 
+Dowload setup script
+```bash
+wget https://raw.githubusercontent.com/puneetsl/lotion/master/setup.sh
+
+# Run
+./setup.sh install
+# Or for native installation
+./setup.sh install_native
+```
+Or simply clone this repo and run 
 
 ```bash
 ./install.sh 

--- a/clean.sh
+++ b/clean.sh
@@ -1,3 +1,6 @@
 #!/bin/sh
 
+# This scripts removes files that are not needed for lotion runtime
+
+rm ./create_shortcut.sh ./install.sh ./install_native.sh ./Lotion-linux-x64.tar.xz
 rm -rf ./nativeApp

--- a/clean.sh
+++ b/clean.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+rm -rf ./nativeApp

--- a/create_shortcut.sh
+++ b/create_shortcut.sh
@@ -19,4 +19,4 @@ StartupWMClass=$1
 EOS
 chmod +x Lotion.desktop
 ## This can be updated if this path is not valid. 
-cp -p Lotion.desktop ~/.local/share/applications
+cp -p Lotion.desktop /usr/share/applications

--- a/create_shortcut.sh
+++ b/create_shortcut.sh
@@ -18,4 +18,3 @@ Icon=${WORKING_DIR}/icon.png
 StartupWMClass=$1
 EOS
 chmod +x Lotion.desktop
-## This can be updated if this path is not valid. 

--- a/create_shortcut.sh
+++ b/create_shortcut.sh
@@ -19,4 +19,3 @@ StartupWMClass=$1
 EOS
 chmod +x Lotion.desktop
 ## This can be updated if this path is not valid. 
-cp -p Lotion.desktop /usr/share/applications

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+required_programs=(git tar)
+
+for cmd in ${required_programs[@]};
+do
+    [ ! $(command -v $cmd) ] && echo Command $cmd is required to run this script && exit -1
+done
+
+cd /tmp
+
+if [ -d lotion ];
+then
+    echo Do you want to use already cashed lotion directory ? [yes/no] && read answer
+    case $answer in
+        "no") echo Downloading ... && rm -rf ./lotion && git clone https://github.com/puneetsl/lotion ;;
+        "yes") echo Using cached directory ... ;;
+        *) echo Invalid response, using cached directory ;;
+    esac
+else
+    echo Downloading ...
+    git clone https://github.com/puneetsl/lotion
+fi
+
+cd ./lotion
+
+echo Copying to /usr/share
+
+rm -rf /usr/share/lotion
+cp -rf ../lotion /usr/share/
+cd /usr/share/lotion
+
+echo Runinng ./$1.sh
+
+[ ! $(./$1.sh) ] && echo Specified installment method \($1\) is not avaible && exit -1
+
+ln -s $PWD/Lotion/Lotion /usr/bin/lotion
+ln -s $PWD/uninstall.sh /usr/bin/lotion_uninstall
+
+./clean.sh

--- a/setup.sh
+++ b/setup.sh
@@ -59,13 +59,16 @@ cd $installation_folder
 echo Runinng ./$cmd.sh
 [ ! $(./$cmd.sh) ] && echo Specified installment method \($cmd\) is not avaible && exit -1
 
+echo Linking executables ...
 # Linking executables for terminal usage
 ln -s $PWD/Lotion/Lotion ${executable_folder}lotion
 ln -s $PWD/uninstall.sh ${executable_folder}lotion_uninstall
 
-# Setup shortcut
+echo Creating shortcut ...
 ./create_shortcut.sh
 cp ./Lotion.desktop ${applications_folder}Lotion.desktop
 
-# Cleaning
+echo Cleaning ...
 ./clean.sh
+
+echo Done !

--- a/setup.sh
+++ b/setup.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+lotion_mirror="https://github.com/puneetsl/lotion"
 required_programs=(git tar)
 
 for cmd in ${required_programs[@]};
@@ -7,7 +8,7 @@ do
     [ ! $(command -v $cmd) ] && echo Command $cmd is required to run this script && exit -1
 done
 
-[ -z "$1" ] && echo Please select of the install types: && echo install && echo install_native && read cmd
+[ -z "$1" ] && echo Please select one of the install types: && echo install && echo install_native && read cmd
 
 [ -n "$1" ] && cmd=$1
 
@@ -17,13 +18,13 @@ if [ -d lotion ];
 then
     echo Do you want to use already cashed lotion directory ? [yes/no] && read answer
     case $answer in
-        "no") echo Downloading ... && rm -rf ./lotion && git clone https://github.com/puneetsl/lotion ;;
+        "no") echo Downloading ... && rm -rf ./lotion && git clone $lotion_mirror ;;
         "yes") echo Using cached directory ... ;;
         *) echo Invalid response, using cached directory ;;
     esac
 else
     echo Downloading ...
-    git clone https://github.com/puneetsl/lotion
+    git clone $lotion_mirror
 fi
 
 cd ./lotion

--- a/setup.sh
+++ b/setup.sh
@@ -7,6 +7,10 @@ do
     [ ! $(command -v $cmd) ] && echo Command $cmd is required to run this script && exit -1
 done
 
+[ -z "$1" ] && echo Please select of the install types: && echo install && echo install_native && read cmd
+
+[ -n "$1" ] && cmd=$1
+
 cd /tmp
 
 if [ -d lotion ];
@@ -30,9 +34,9 @@ rm -rf /usr/share/lotion
 cp -rf ../lotion /usr/share/
 cd /usr/share/lotion
 
-echo Runinng ./$1.sh
+echo Runinng ./$cmd.sh
 
-[ ! $(./$1.sh) ] && echo Specified installment method \($1\) is not avaible && exit -1
+[ ! $(./$cmd.sh) ] && echo Specified installment method \($cmd\) is not avaible && exit -1
 
 ln -s $PWD/Lotion/Lotion /usr/bin/lotion
 ln -s $PWD/uninstall.sh /usr/bin/lotion_uninstall

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
 PD=`pwd`
 INSTALL_DIR=$PD"/Lotion"
+
+[ -d /usr/share/lotion ] INSTALL_DIR="/usr/share/lotion"
+
 rm -r $INSTALL_DIR
-rm ~/.local/share/applications/Lotion.desktop
+rm /usr/share/applications/Lotion.desktop
+rm /usr/bin/lotion
+rm /usr/bin/lotion_uninstall

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -1,10 +1,18 @@
 #!/bin/bash
 PD=`pwd`
-INSTALL_DIR=$PD"/Lotion"
 
-[ -d /usr/share/lotion ] INSTALL_DIR="/usr/share/lotion"
+if [ -d /usr/share/lotion ]
+then
+INSTALL_DIR="/usr/share/lotion"
+SHORTCUT_DIR="/usr/share/applications/"
+EXEC_DIR="/usr/bin/"
+else
+INSTALL_DIR=$PD"/Lotion"
+SHORTCUT_DIR="~/.local/share/applications/"
+EXEC_DIR="~/.local/bin/"
+fi
 
 rm -r $INSTALL_DIR
-rm /usr/share/applications/Lotion.desktop
-rm /usr/bin/lotion
-rm /usr/bin/lotion_uninstall
+rm $SHORTCUT_DIR/Lotion.desktop
+rm $EXEC_DIR/lotion
+rm $EXEC_DIR/lotion_uninstall


### PR DESCRIPTION
I wrote a simple script (`setup.sh`) that installs Lotion in `/usr/share/lotion` and uses respectively `install.sh` or `install_native.sh`, which also links `Lotion` (executable) and `uninstall.sh` to `/usr/bin` so it is accessible from command line.
Furthermore I modified `setup_shortcut.sh` as well as `uninstall.sh` to install desktop entry in `/usr/share/applications`. 
I also wrote a simple `clean.sh` script that cleans `/usr/share/lotion` out of non runtime required files (runs automatically in `setup.sh`).
Also modified `README`.