### PR TITLE
Fixed lotion mirror url.

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-lotion_mirror="https://github.com/Mazurel/lotion"
+lotion_mirror="https://github.com/puneetsl/lotion"
 required_programs=(git tar)
 
 # Check for required programs


### PR DESCRIPTION
When submitting pull request for `setup.sh` I forgot to change `lotion_mirror` variable (which was set to my repo for testing purposes), which resulted in cloning my forked repository instead of proper lotion repository. Really sorry for that one as it could have resulted in some issues. 