### PR TITLE
Explicitly enter StartupWMClass

### DIFF
--- a/create_shortcut.sh
+++ b/create_shortcut.sh
@@ -15,6 +15,6 @@ Terminal=false
 Categories=Office;TextEditor;Utility
 Type=Application
 Icon=${WORKING_DIR}/icon.png
-StartupWMClass=$1
+StartupWMClass=Notion
 EOS
 chmod +x Lotion.desktop


### PR DESCRIPTION
The `$1` parameter does not always result in a working link to the Lotion icon. Fixes #94. 