### PR TITLE
fix: allow opening second window

### DIFF
--- a/src/main/controllers/AppController.js
+++ b/src/main/controllers/AppController.js
@@ -38,26 +38,21 @@ class AppController {
     this.electronApp.whenReady().then(() => {
       log.info('Electron app is ready via AppController');
       
-      // Parse command line arguments for initial URL
+      // Parse command line arguments for Notion URL
       const args = process.argv;
-      log.info('Command line arguments:', args);
-      
       let initialUrl = null;
-      // Look for URLs in command line arguments (skip first 2 args which are electron and app path)
-      for (let i = 2; i < args.length; i++) {
-        const arg = args[i];
-        if (arg && (arg.startsWith('http://') || arg.startsWith('https://'))) {
+      // Find any argument that is a Notion URL
+      for (const arg of args) {
+        if (arg && 
+            (arg.startsWith('http://') || arg.startsWith('https://')) && 
+            arg.includes('notion.so')) {
           initialUrl = arg;
-          log.info(`Found URL in command line: ${initialUrl}`);
+          log.info(`Found Notion URL: ${initialUrl}`);
           break;
         }
       }
       
-      const options = {};
-      if (initialUrl) {
-        options.initialUrl = initialUrl;
-      }
-
+      const options = initialUrl ? { initialUrl } : {};
       this.createNewWindow(options);
     });
 

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -56,32 +56,20 @@ const appController = new AppController(reduxStore);
 // We create a NEW WINDOW instead of focusing existing one
 app.on('second-instance', (event, commandLine, workingDirectory) => {
   log.info('Second instance detected, creating new window');
-  log.info('Command line:', commandLine);
-  log.info('Working directory:', workingDirectory);
 
-  // Parse command line to extract URL if provided
-  // Command line format: ['electron', '/path/to/app', 'https://notion.so/...']
+  // Find any argument that is a Notion URL
   let initialUrl = null;
-  
-  // Look for URLs in command line arguments (skip first 2 args which are electron and app path)
-  for (let i = 2; i < commandLine.length; i++) {
-    const arg = commandLine[i];
-    if (arg && (arg.startsWith('http://') || arg.startsWith('https://'))) {
+  for (const arg of commandLine) {
+    if (arg && 
+        (arg.startsWith('http://') || arg.startsWith('https://')) && 
+        arg.includes('notion.so')) {
       initialUrl = arg;
-      log.info(`Found URL in command line: ${initialUrl}`);
+      log.info(`Found Notion URL: ${initialUrl}`);
       break;
     }
   }
 
-  // Create a new window with the URL if provided
-  const options = {};
-  if (initialUrl) {
-    options.initialUrl = initialUrl;
-    log.info(`Creating new window with URL: ${initialUrl}`);
-  } else {
-    log.info('Creating new window with default URL');
-  }
-
+  const options = initialUrl ? { initialUrl } : {};
   appController.createNewWindow(options);
 });
 


### PR DESCRIPTION
This should fix #138  I think.

If a second instance is requested, we abort and instead pass to the first instance, which handles multiple windows natively.

I've left in the log statements as I saw you have them but feel free to remove.

To test in dev, in 1 terminal run `npm run dev` and in another terminal run another `npm run dev`. The second should abort early with a log message: "Another instance of Lotion is already running. Quitting this instance." and the new window should pop right up.

This also handles passing URLs to lotion. So if you have an existing `npm run dev` instance and separately run:
`npx electron . "<notion.so link directly to your note>"`
e.g.
`npx electron . "https://www.notion.so/bar"`

In the newly opened window, you will see the targeted note.

Works if this is done in a single window, too.